### PR TITLE
Add ClawdTalk to Skill Registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Access the web dashboard at `http://localhost:18789/` to chat and manage your ag
 
 - [ClawHub](https://clawhub.ai/) - Official skill store (700+ skills)
 - [AgentFund](https://github.com/RioTheGreat-ai/agentfund-skill) - Crowdfunding platform for AI agents (milestone-based escrow on Base)
+- [ClawdTalk](https://github.com/team-telnyx/clawdtalk-client) - Phone calling and SMS for OpenClaw. Call your AI agent from any phone with deep tool integration for calendar, Jira, web search, and more. Powered by Telnyx.
 - [awesome-openclaw-skills](https://github.com/VoltAgent/awesome-openclaw-skills) - Community curated collection
 - [openclaw/skills](https://github.com/openclaw/skills) - Official skills repository
 - [openclaw/clawhub](https://github.com/openclaw/clawhub) - Skill directory source


### PR DESCRIPTION
Adds ClawdTalk, a phone calling and SMS skill for OpenClaw powered by Telnyx, to the Skill Registries section.