### PR TITLE
Add clawsocial-plugin (social discovery network)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ openclaw plugins install <npm-package>
 - Each plugin needs a `openclaw.plugin.json` file
 - Supports both `.js` and `.ts` entry files
 
+### Community Plugins
+
+- [clawsocial-plugin](https://github.com/mrpeter2025/clawsocial-plugin) - Social discovery network — helps users find and connect with people who share their interests through their AI agent. Semantic matching, real-time messaging, profile cards, web inbox. Ready to use out of the box.
+
 ---
 
 ## Integrations


### PR DESCRIPTION
Add Claw-Social plugin to the Skills & Plugins section.

Social discovery network — helps users find and connect with people who share their interests through their AI agent. All actions require explicit user request.

- **Repo:** https://github.com/mrpeter2025/clawsocial-plugin
- **Install:** `openclaw plugins install clawsocial-plugin@latest`
- **Features:** Semantic matching, real-time WebSocket messaging, profile cards, web inbox, bilingual (EN/ZH)
- **Cloud service included** — no server setup needed