### PR TITLE
Add Not Human Search to MCP Servers table

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ OpenClaw supports the **Model Context Protocol (MCP)** — the open standard ado
 | [defi-mcp](https://github.com/OzorOwn/defi-mcp) | DeFi MCP server with 12 tools: real-time crypto prices, multi-chain wallet balances (9 chains), DEX quotes via Jupiter and Li.Fi, and token search across 275+ assets. No API key required. |
 | [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) | X API & Twitter scraper skill for AI coding agents. 40+ tools: tweet search, user lookup, follower extraction, engagement metrics, giveaway draws, trending topics, write actions, Telegram integrations. REST API, MCP server & webhooks. Works with Claude Code, Cursor, Codex, Copilot, Windsurf & 40+ agents. |
 | [ToolRouter](https://toolrouter.com) | One gateway to 150+ tools for AI agents — SEO, screenshots, web search, image generation, video, security scanning, and more. One API key replaces managing dozens of provider accounts. Works with ChatGPT, Claude, Cursor, and any MCP client. `npx -y toolrouter-mcp` |
+| [Not Human Search](https://nothumansearch.ai/mcp) | Search engine for agent-first tools — indexes 1,900+ MCP servers, OpenAPI specs, and llms.txt endpoints scored by agentic readiness. Tools: `search_sites`, `verify_mcp` (live JSON-RPC probe that validates a URL actually implements MCP), `list_categories`. Public, free, no auth. Streamable HTTP at `https://nothumansearch.ai/mcp`. |
 
 - [AnChain.AI + OpenClaw Guide](https://www.anchain.ai/blog/openclaw) - Build 24x7 AML Compliance AI Agent
 


### PR DESCRIPTION
Adds [Not Human Search](https://nothumansearch.ai/mcp) to the **MCP Servers** table, alongside entries like meyhem-search, skillsync-mcp, and ToolRouter.

NHS is a search engine and discovery layer for agent-first tools — indexes 1,900+ MCP servers, OpenAPI specs, llms.txt endpoints, and ai-plugin manifests, scored by agentic readiness across 7 signals. For OpenClaw users, it answers "which MCP servers exist for my task?" via MCP or REST.

Tools exposed:
- `search_sites` — tsvector-ranked search
- `verify_mcp` — live JSON-RPC probe (`initialize` + `tools/list`) that validates a URL actually implements MCP before wiring in
- `list_categories`, `get_top_sites`, `check_url`, `submit_site`, `get_site_details`, `get_stats`

Public, free, no auth. Published to the official MCP registry as `ai.nothumansearch/search`.