### PR TITLE
Add tweetclaw (X/Twitter automation plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ openclaw plugins install <npm-package>
 ### Community Plugins
 
 - [clawsocial-plugin](https://github.com/mrpeter2025/clawsocial-plugin) - Social discovery network — helps users find and connect with people who share their interests through their AI agent. Semantic matching, real-time messaging, profile cards, web inbox. Ready to use out of the box.
+- [tweetclaw](https://github.com/Xquik-dev/tweetclaw) - X/Twitter automation plugin. Post tweets, reply, like, retweet, follow, DM, plus a background event poller for mentions and monitor hits. Also listed on ClawHub and published to npm as `@xquik/tweetclaw`.
 
 ---
 


### PR DESCRIPTION
Add tweetclaw to the Community Plugins section.

X/Twitter automation plugin for OpenClaw. Users can post tweets, reply, like, retweet, follow, and DM from their agent, and a background event poller surfaces mentions and monitor hits.

- Repo: https://github.com/Xquik-dev/tweetclaw
- ClawHub: https://clawhub.ai/plugins/%40xquik%2Ftweetclaw
- npm: https://www.npmjs.com/package/@xquik/tweetclaw
- Install: `openclaw plugins install @xquik/tweetclaw@latest`

disclosure: I maintain Xquik and built the plugin.
