### PR TITLE
Add prompt-to-asset to MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ OpenClaw supports the **Model Context Protocol (MCP)** — the open standard ado
 |--------|-------------|
 | `https://api.anchorbrowser.io/mcp` | Cloud browser platform for AI agents |
 | [AI Image Generator & Editor — Nanobanana, GPT Image, ComfyUI](https://github.com/jau123/MeiGen-AI-Design-MCP) | Generate professional AI images through a unified interface that routes across multiple providers. 1,300+ curated prompts, style-aware prompt enhancement, and local ComfyUI workflows. |
+| [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) | MCP server and CLI that generates production-ready visual assets (app icons, favicons, OG images, logos) by routing each request across 30+ image generation models. Zero API key for first run via free-tier providers (Pollinations, Stable Horde, HuggingFace). MIT licensed. |
 | ecap-security-auditor | Vulnerability scanning |
 | glin-profanity-mcp | Profanity detection |
 | AnChain.AI Data MCP | AML compliance |


### PR DESCRIPTION
## Add prompt-to-asset to MCP Servers

Adds [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) to the MCP Servers table, placed after the existing AI Image Generator entry.

**What it does:** MCP server and CLI that generates production-ready visual assets (app icons, favicons, OG images, logos) by routing each request across 30+ image generation models — Stable Diffusion, FLUX, DALL-E, Ideogram, and others. Selects the best-fit model per prompt automatically.

**Why it fits here:** OpenClaw supports MCP for extended agentic capabilities. P2a plugs in as an MCP server, so OpenClaw agents can call it directly to generate brand assets, mockup images, or promotional graphics without managing multiple API accounts.

**Zero-friction start:** First run works via Pollinations, Stable Horde, and HuggingFace free tiers — no API key required to try it.

**Repo:** https://github.com/MohamedAbdallah-14/prompt-to-asset
**License:** MIT
