### PR TITLE
Add install-openclaw.net to Tutorials & Guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ OpenClaw supports the **Model Context Protocol (MCP)** — the open standard ado
 | [What is OpenClaw?](https://www.digitalocean.com/resources/articles/what-is-openclaw) | DigitalOcean | Comprehensive explainer |
 | [Complete Installation Guide](https://www.aifreeapi.com/en/posts/openclaw-installation-guide) | AI Free API | WhatsApp, Telegram, Discord setup |
 | [ClawPath](https://clawpath.dev) | Community | Chinese & English onboarding guide — install, channel, skills, security in 30 min |
+| [Install OpenClaw Guide](https://install-openclaw.net) | install-openclaw.net | Step-by-step VPS & local setup guides, Telegram/VPS install tutorials |
 
 ### Advanced
 


### PR DESCRIPTION
Adds [install-openclaw.net](https://install-openclaw.net) — a comprehensive step-by-step OpenClaw installation guide covering VPS and local setup, Telegram integration, and deployment tutorials.

This is a free community resource that helps users get started with OpenClaw on their own infrastructure.