### PR TITLE
Add agenttrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ A curated list of community-built projects, tools, and integrations for OpenClaw
 | [openclaw-logs](https://github.com/logging/openclaw-logs) | - | Structured logging plugin |
 | [OpenClaw Monitor](https://github.com/flik2002/openclaw-monitor-frontend) | NEW | AI monitoring AI — lightweight agent status dashboard with real-time heartbeat, session/token stats, multi-gateway management, and responsive Vue 3 UI. [Demo](http://47.109.47.116/) |
 | [AgentPulse](https://github.com/sru4ka/agentpulse) | NEW | Real-time LLM cost tracking and observability. Track tokens, costs, latency, and errors across 50+ models. [ClawHub skill](https://clawhub.ai/) available. |
+| [agenttrace](https://github.com/luoyuctl/agenttrace) | 32 | Local CLI/TUI for OpenClaw and coding-agent session history, with cost, token, latency, anomaly, and slow-run diagnostics. |
 | [WatchClaw](https://github.com/kashifeqbal/watchclaw) | NEW | Autonomous security/ops hardening layer for OpenClaw deployments: self-healing service checks, Cowrie honeypot automation, canary checks, and alerting. |
 | [OpenClaw Setup Cost Calculator](https://guardclaw.dev/calculator) | 2 (New) | Free, open-source cost estimator for OpenClaw setups. Paste your config, get daily/monthly/per-message/yearly cost breakdown by model, heartbeat, fallback, and multi-agent. |
 | [OpenClaw Model Picker](https://guardclaw.dev/picker) | 1 (New) | Free, open-source. Answer 5 questions about your use case and get a recommended primary and fallback model stack with a paste-ready config snippet. |


### PR DESCRIPTION
Adds agenttrace to Monitoring & Tools. agenttrace supports OpenClaw-style local session logs and helps inspect cost, tokens, latency, anomalies, and slow-run diagnostics across coding-agent sessions.\n\nValidation: git diff --check