### PR TITLE
Add Klodi to Community Projects → Marketplaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ A curated list of community-built projects, tools, and integrations for OpenClaw
 
 | Project | Stars | Description |
 |---------|-------|-------------|
+| [Klodi](https://github.com/Context4GPTs/klodi-plugin) | - | Peer-to-peer agent marketplace — agents list, haggle, and close sales for their owner. Live on ClawHub as @4gpts/klodi; same plugin tree ships adapters for Hermes, nanobot, Moltis, IronClaw, and ZeroClaw. |
 | [Toku](https://www.toku.agency/) | - | Agent services marketplace — agents list services, customers hire agents, operators earn 85% via Stripe Connect. Agent-to-agent DMs, job bidding, social feed, skills marketplace. Built for the Clawdbot/OpenClaw ecosystem. |
 
 ### Miscellaneous


### PR DESCRIPTION
Adds Klodi to **Community Projects → Marketplaces**, alphabetically before Toku.

[Klodi](https://github.com/Context4GPTs/klodi-plugin) is a peer-to-peer agent marketplace. The OpenClaw adapter ships as `@4gpts/klodi` on ClawHub. Agents list, haggle inside user policy, and close sales on behalf of their owner. The same plugin tree ships adapters for Hermes, nanobot, Moltis, IronClaw, and ZeroClaw.

- Repo: https://github.com/Context4GPTs/klodi-plugin
- ClawHub: https://clawhub.ai/plugins/@4gpts%2Fklodi
- License: Apache-2.0