### PR TITLE
Add OneQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ openclaw plugins install <npm-package>
 ### Community Plugins
 
 - [clawsocial-plugin](https://github.com/mrpeter2025/clawsocial-plugin) - Social discovery network — helps users find and connect with people who share their interests through their AI agent. Semantic matching, real-time messaging, profile cards, web inbox. Ready to use out of the box.
+- [OneQuery](https://github.com/wordbricks/onequery/tree/main/packages/openclaw-plugin) - Agent-ready CLI/skill for bounded, auditable queries against approved data sources through centralized credentials, read-only validation, limits, and audit logs.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ openclaw plugins install <npm-package>
 ### Community Plugins
 
 - [clawsocial-plugin](https://github.com/mrpeter2025/clawsocial-plugin) - Social discovery network — helps users find and connect with people who share their interests through their AI agent. Semantic matching, real-time messaging, profile cards, web inbox. Ready to use out of the box.
-- [OneQuery](https://github.com/wordbricks/onequery/tree/main/packages/openclaw-plugin) - Agent-ready CLI/skill for bounded, auditable queries against approved data sources through centralized credentials, read-only validation, limits, and audit logs.
+- [OneQuery](https://github.com/wordbricks/onequery/tree/main/packages/openclaw-plugin) - CLI skill for safe, auditable agent queries against approved data sources.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ openclaw plugins install <npm-package>
 ### Community Plugins
 
 - [clawsocial-plugin](https://github.com/mrpeter2025/clawsocial-plugin) - Social discovery network — helps users find and connect with people who share their interests through their AI agent. Semantic matching, real-time messaging, profile cards, web inbox. Ready to use out of the box.
-- [OneQuery](https://github.com/wordbricks/onequery/tree/main/packages/openclaw-plugin) - CLI skill for safe, auditable agent queries against approved data sources.
+- [OneQuery](https://github.com/wordbricks/onequery/tree/main/packages/openclaw-plugin) - CLI skill for safe, auditable queries for agents against approved data sources.
 
 ---
 


### PR DESCRIPTION
Adds OneQuery to Skills & Plugins / Community Plugins.

OneQuery is an OpenClaw plugin for safe, auditable queries for agents against approved data sources.

Guideline check:
- One link in this PR.
- Description is short, neutral, and follows the existing list format.
- Link works and no duplicate OneQuery entry was found before submission.
- Disclosure: I am affiliated with Wordbricks/OneQuery.