### PR TITLE
Update README with new project entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ A curated list of community-built projects, tools, and integrations for OpenClaw
 | [WatchClaw](https://github.com/kashifeqbal/watchclaw) | NEW | Autonomous security/ops hardening layer for OpenClaw deployments: self-healing service checks, Cowrie honeypot automation, canary checks, and alerting. |
 | [OpenClaw Setup Cost Calculator](https://guardclaw.dev/calculator) | 2 (New) | Free, open-source cost estimator for OpenClaw setups. Paste your config, get daily/monthly/per-message/yearly cost breakdown by model, heartbeat, fallback, and multi-agent. |
 | [OpenClaw Model Picker](https://guardclaw.dev/picker) | 1 (New) | Free, open-source. Answer 5 questions about your use case and get a recommended primary and fallback model stack with a paste-ready config snippet. |
+| [Claw Lens](https://github.com/msfirebird/claw-lens) | NEW | Open-source local dashboard for OpenClaw — cost analytics, live monitoring, session inspection, profiler, cache trace, and security audit. |
 
 ### Trading & Finance
 


### PR DESCRIPTION
Add claw-lens project to README monitoring & tooling section.
A local-first dashboard for OpenClaw combining observability, cost analytics, and debugging/inspection.

npm: npx claw-lens-cli

repo: https://github.com/msfirebird/claw-lens
docs: https://claw-lens.com