### PR TITLE
feat: add TWZRD Agent Intel to MCP Servers — Solana AI agent trust scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ OpenClaw supports the **Model Context Protocol (MCP)** — the open standard ado
 - [AnChain.AI + OpenClaw Guide](https://www.anchain.ai/blog/openclaw) - Build 24x7 AML Compliance AI Agent
 
 ---
+| [TWZRD Agent Intel](https://intel.twzrd.xyz) | Trust scoring for Solana AI agents. `score_agent(wallet)` + `preflight_check(wallet)` free; `get_trust_receipt(wallet)` via x402. Config: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}` |
 
 ## Tutorials & Guides
 


### PR DESCRIPTION
## What this adds

[TWZRD Agent Intel](https://intel.twzrd.xyz) to the **MCP Servers** section.

## Why it fits

OpenClaw deployments increasingly operate as autonomous agents handling payments and multi-agent coordination. TWZRD Agent Intel provides on-chain trust scoring for Solana AI agents — letting an OpenClaw instance verify another agent's wallet identity and behavioral history before initiating x402 micropayments or sharing resources in multi-agent workflows.

**Tools:**
- `score_agent(wallet)` — trust score (0–1), behavioral flags. Free.
- `preflight_check(wallet)` — go/no-go verdict before agent interactions. Free.
- `get_trust_receipt(wallet)` — signed trust receipt for audit trails. Paid via x402 (~$0.001 USDC).

**Config:**
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```