### PR TITLE
Add CreatorSkills to Skill Registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Access the built-in web dashboard at `http://localhost:18789/` to chat, manage i
 - [openclaw/skills](https://github.com/openclaw/skills) - Official skills repository
 - [openclaw/clawhub](https://github.com/openclaw/clawhub) - Skill directory source
 - [Skills.sh](https://skills.sh/openclaw/openclaw) - Skill discovery platform
+- [CreatorSkills](https://creatorskills.co) - Marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, content repurposing, and audience growth
 - [night-market](https://github.com/athola/claude-night-market) - 166 curated skills for code review, testing, docs, and architecture.
 
 ### Notable Skills


### PR DESCRIPTION
## What

Adds [CreatorSkills](https://creatorskills.co) to the **Skill Registries** section alongside ClawHub, Skills.sh, and other skill discovery platforms.

## Why

CreatorSkills is a marketplace of 30+ downloadable AI skills built on the SKILL.md open standard. It's a natural addition to the Skill Registries section as an established production marketplace — focused specifically on content creator workflows (YouTube scripting, sponsorship analysis, content repurposing, audience growth), filling a niche not covered by the developer-focused registries already listed.

## Entry added

```
- [CreatorSkills](https://creatorskills.co) - Marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, content repurposing, and audience growth
```