### PR TITLE
Add VideoOverlayKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ OpenClaw supports the **Model Context Protocol (MCP)** — the open standard ado
 
 ---
 | [TWZRD Agent Intel](https://intel.twzrd.xyz) | Trust scoring for Solana AI agents. `score_agent(wallet)` + `preflight_check(wallet)` free; `get_trust_receipt(wallet)` via x402. Config: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}` |
+| [VideoOverlayKit](https://github.com/alichherawalla/video-overlay-kit) | Render 4-6s animated b-roll overlay videos (mp4) for short-form social (LinkedIn, IG Reels, YouTube Shorts, TikTok) and landscape YouTube. AI-driven via MCP: paste your script into Claude Code / Cursor / Codex, the model writes the scene spec and renders the mp4. Built on Remotion + Tabler + Lottie. npm: `@alichherawalla/video-overlay-kit`. Free, MIT, local. |
 
 ## Tutorials & Guides
 


### PR DESCRIPTION
Adds [VideoOverlayKit](https://github.com/alichherawalla/video-overlay-kit) to the MCP Servers table. AI-driven animated b-roll overlay renderer for short-form video — paste your script into your AI coding tool, the MCP server writes the scene spec and renders an mp4. Built on Remotion + Tabler + Lottie. npm: @alichherawalla/video-overlay-kit. Free, MIT, local. Preview: https://alichherawalla.github.io/video-overlay-kit/