### PR TITLE
Add erpclaw (AI-native open-source ERP + accounting) to Enterprise Solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ A curated list of community-built projects, tools, and integrations for OpenClaw
 | [archestra](https://github.com/enterprise/archestra) | 2.8k | OpenClaw for Enterprise with RBAC |
 | [openclaw-saml](https://github.com/auth0/openclaw-saml) | - | SAML authentication for OpenClaw |
 | [claw-audit](https://github.com/compliance/claw-audit) | - | Audit logging and compliance tools |
+| [erpclaw](https://github.com/avansaber/erpclaw) |  | AI-native open-source ERP + double-entry accounting, self-hosted, run in plain English |
 
 ### Chinese IM Integrations
 

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ A curated list of community-built projects, tools, and integrations for OpenClaw
 | [archestra](https://github.com/enterprise/archestra) | 2.8k | OpenClaw for Enterprise with RBAC |
 | [openclaw-saml](https://github.com/auth0/openclaw-saml) | - | SAML authentication for OpenClaw |
 | [claw-audit](https://github.com/compliance/claw-audit) | - | Audit logging and compliance tools |
-| [erpclaw](https://github.com/avansaber/erpclaw) |  | AI-native open-source ERP + double-entry accounting, self-hosted, run in plain English |
+| [erpclaw](https://github.com/avansaber/erpclaw) | 47 | AI-native open-source ERP + double-entry accounting, self-hosted, run in plain English |
 
 ### Chinese IM Integrations
 


### PR DESCRIPTION
Adding **erpclaw** to Enterprise Solutions.

**What it is:** AI-native, open-source (GPL v3), self-hosted ERP + double-entry accounting you run in plain English — invoicing, inventory, general ledger, payroll, multi-company books in one shared database. Installs on OpenClaw via ClawHub.

**Repo:** https://github.com/avansaber/erpclaw (agentskills.io `SKILL.md`, README, tests).

Not a duplicate; public working repo; maintained. Followed the existing `| Project | Stars | Description |` table format.