### PR TITLE
Add OpenClaw ecosystem survey (Articles & News → Research & Surveys)

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,10 @@ OpenClaw supports the **Model Context Protocol (MCP)** — the open standard ado
 
 - [What Security Teams Need to Know](https://www.crowdstrike.com/en-us/blog/what-security-teams-need-to-know-about-openclaw-ai-super-agent/) - CrowdStrike
 
+### Research & Surveys
+
+- [OpenClaw as Language Infrastructure: A Case-Centered Survey of a Public Agent Ecosystem in the Wild](https://www.preprints.org/manuscript/202603.1060) - Preprints.org · academic survey of the OpenClaw ecosystem across Platform, Security, Societies, and Deployment
+
 ---
 
 ## Community


### PR DESCRIPTION
Adds the academic survey **"OpenClaw as Language Infrastructure: A Case-Centered Survey of a Public Agent Ecosystem in the Wild"** under **Articles & News**, in a new **Research & Surveys** subsection (the section currently holds press links only, so a research entry fits cleanly there).

It is a case-centered survey of the OpenClaw ecosystem organized around four dimensions — Platform, Security, Societies, and Deployment — synthesizing the published OpenClaw research corpus (~38 works incl. ClawHub/Skills, Heartbeat, Moltbook).

Link: https://www.preprints.org/manuscript/202603.1060

Disclosure: I am an author of this survey. Entry kept factual and neutral; happy to relocate it if you prefer a different section.