### PR TITLE
Add Armorer Guard to OpenClaw security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,7 @@ OpenClaw is often compared to other autonomous AI agents and self-hosted AI assi
 | [APort Agent Guardrails](https://github.com/aporthq/aport-agent-guardrails) | - | Pre-action authorization for OpenClaw; `before_tool_call` plugin, allowlist + 40+ blocked patterns, local or API. Setup: `npx @aporthq/agent-guardrails` |
 | [leashed](https://github.com/dormstern/leashed) | - | Policy engine, audit log, and kill switch for AI agents. Allow/deny patterns, time limits, and emergency revocation. |
 | [OneCLI](https://github.com/onecli/onecli) | - | Open-source credential vault for AI agents. Rust HTTP gateway injects API keys transparently so agents never handle raw secrets. Per-agent scoped tokens, AES-256-GCM encryption at rest. |
+| [Armorer Guard](https://github.com/ArmorerLabs/Armorer-Guard) | - | Local Rust scanner and MCP proxy for AI-agent prompt injection, credential leakage, exfiltration, and risky tool-call arguments before execution. |
 | [ClawLens](https://github.com/nk3750/clawlens) | - | Local-first observability and guardrails for OpenClaw agents — records every tool call before execution, scores risky behavior, keeps a tamper-evident hash-chain audit trail, and turns observed actions into block / require-approval / allow-notify guardrails delivered to Telegram. |
 | [iClaw](https://github.com/iclawapp/iclaw) | - | Local-first AI workspace with sandboxed file execution — isolates files in containers, detects malware and credential theft before execution. npm: @iclawapp/iclaw |
 | [trentclaw](https://github.com/trnt-ai/trent-openclaw-security-assessment) | - | Security assessment skill for OpenClaw — scans gateway config, installed skills, tool permissions, and MCP servers, finds chained attack paths, and returns prioritized findings with proposed fixes inside your OpenClaw session. [ClawHub](https://clawhub.ai/trent-ai-release/trentclaw) · `clawhub install trentclaw` |
@@ -597,4 +598,3 @@ This list is released into the public domain under CC0 1.0.
 ---
 
 *Last updated: February 2026*
-


### PR DESCRIPTION
Adds Armorer Guard to the Security Tools section. I maintain Armorer Guard at Armorer Labs; it is an MIT-licensed local Rust scanner/MCP proxy for prompt injection, credential leakage, exfiltration, and risky tool-call arguments in OpenClaw-style agent runtimes.