### PR TITLE
Add Skill Hub to Skill Registries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ Access the built-in web dashboard at `http://localhost:18789/` to chat, manage i
 - [openclaw/clawhub](https://github.com/openclaw/clawhub) - Skill directory source
 - [Skills.sh](https://skills.sh/openclaw/openclaw) - Skill discovery platform
 - [CreatorSkills](https://creatorskills.co) - Marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, content repurposing, and audience growth
-- [night-market](https://github.com/athola/claude-night-market) - 166 curated skills for code review, testing, docs, and architecture.
+|- [night-market](https://github.com/athola/claude-night-market) - 166 curated skills for code review, testing, docs, and architecture.
+|- [Skill Hub](https://github.com/rdone4425/skill) - Cross-platform AI Agent Skills directory with 5,000+ skills across 22 categories. Discover skills for Claude Code, Codex, OpenClaw, Hermes, and OpenCode. Open source (MIT), searchable, filterable.
 
 ### Notable Skills
 


### PR DESCRIPTION
Add [Skill Hub](https://github.com/rdone4425/skill) to the Skills & Plugins > Skill Registries section. Skill Hub is a cross-platform AI Agent Skills directory with 5,000+ skills across 22 categories, including OpenClaw-compatible skills.

https://skill.442595.xyz/

Open source (MIT), searchable, filterable, and actively maintained.