### PR TITLE
Add ClawStat.us (release-safety verdicts for OpenClaw)

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ A curated list of community-built projects, tools, and integrations for OpenClaw
 | [OpenClaw Setup Cost Calculator](https://guardclaw.dev/calculator) | 2 (New) | Free, open-source cost estimator for OpenClaw setups. Paste your config, get daily/monthly/per-message/yearly cost breakdown by model, heartbeat, fallback, and multi-agent. |
 | [OpenClaw Model Picker](https://guardclaw.dev/picker) | 1 (New) | Free, open-source. Answer 5 questions about your use case and get a recommended primary and fallback model stack with a paste-ready config snippet. |
 | [Claw Lens](https://github.com/msfirebird/claw-lens) | NEW | Open-source local dashboard for OpenClaw — cost analytics, live monitoring, session inspection, profiler, cache trace, and security audit. |
+| [ClawStat.us](https://clawstat.us) | NEW | Automated, evidence-backed verdict on whether to update to the latest OpenClaw release — scouts post-release bug reports, scores them from the repo's own severity labels, and has two independent LLMs cross-check the call. Free, open source, with a JSON API and an `llms.txt` mirror for agents. [Source](https://github.com/camilla-oclm/openclaw_status_app) |
 
 ### Trading & Finance
 


### PR DESCRIPTION
Adds ClawStat.us — a free, open-source tool that answers "should I update to the latest
OpenClaw release?" with an evidence-backed verdict (update now / with precautions / skip).

- Scouts post-release bug reports and scores them from the repo's real severity labels,
  ranked by whether they affect the assessed version.
- Two independent LLM providers (analyst + validator) cross-check before anything ships.
- Human page + JSON API + RSS + an llms.txt/llms-full.txt mirror for agents.

Live: https://clawstat.us  ·  Source: https://github.com/camilla-oclm/openclaw_status_app

Added as the newest row in Community Projects → Monitoring & Tools, matching the table
format ("NEW" in the stars column). Happy to adjust wording or placement.