### PR TITLE
Add Tura to OpenClaw alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@ OpenClaw is often compared to other autonomous AI agents and self-hosted AI assi
 | [AutoGPT](https://github.com/Significant-Gravitas/AutoGPT) | Open Source | Autonomous task execution |
 | [Open Interpreter](https://github.com/OpenInterpreter/open-interpreter) | Open Source | Terminal-based code execution |
 | [Claude Code](https://claude.ai/code) | Proprietary | Developer coding assistance |
+| [Tura](https://github.com/Tura-AI/tura) | Open Source | Local open-source coding agent that understands a repository before changing it |
 | [claw-army/claude-node](https://github.com/claw-army/claude-node) | Open Source | Python subprocess bridge for Claude Code CLI, giving Python code direct access to Claude Code native capabilities via stream-json |
 | [Jan.ai](https://jan.ai/) | Open Source | Privacy-focused, fully offline |
 | [Agent Zero](https://github.com/frdel/agent-zero) | Open Source | Fully local autonomous agent |


### PR DESCRIPTION
## Summary

- Add Tura to the Alternatives & Comparisons table next to other coding and terminal agents.
- Keep the change to one README row, following the repository's one-resource-per-line guidance.

## Tura

Tura: 16.7% better performance, 77.5% fewer rounds.

Tura is a local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it.

Public benchmark: https://turaai.net/benchmark

## Fit

The table already includes Claude Code under developer coding assistance. Tura fits the same comparison area as a local open-source coding agent, and the brief table description preserves the README positioning that it understands a repository before changing it.

## Disclosure

I am affiliated with the Tura project. This contribution was prepared with AI assistance and reviewed against the target README, contribution guidance, live duplicate searches, and the current Tura README.