### PR TITLE
docs(tutorials-beginner): add clawdbot.tech — multilingual OpenClaw deployment archive (5 languages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ OpenClaw supports the **Model Context Protocol (MCP)** — the open standard ado
 | [Complete Installation Guide](https://www.aifreeapi.com/en/posts/openclaw-installation-guide) | AI Free API | WhatsApp, Telegram, Discord setup |
 | [ClawPath](https://clawpath.dev) | Community | Chinese & English onboarding guide — install, channel, skills, security in 30 min |
 | [Install OpenClaw Guide](https://install-openclaw.net) | install-openclaw.net | Step-by-step VPS & local setup guides, Telegram/VPS install tutorials |
+| [Clawdbot](https://clawdbot.tech/) | Community | Multilingual (EN / 中文 / 日本語 / 한국어 / Español) deployment archive — 30+ guides on Docker, VPS, NAS, security whitepaper, and full rename history |
 
 ### Advanced
 


### PR DESCRIPTION
## Summary

Adds [clawdbot.tech](https://clawdbot.tech/) to **Tutorials & Guides → Beginner** as the only multilingual (5-language) deployment guide in the table.

## Why clawdbot.tech?

| Property | Value |
|----------|-------|
| **Languages** | English, 中文 (Simplified & Traditional), 日本語, 한국어, Español (5) |
| **Content** | 30+ deployment guides covering VPS, Docker, security hardening, channel setup, local LLM (Ollama/LM Studio) |
| **Unique** | Security whitepaper + complete rename history (Clawdbot → Moltbot → OpenClaw) |
| **Audience** | Non-English-speaking OpenClaw users (KR/JP/ES/中文 markets that are underserved by current entries) |
| **License** | Content is CC-BY-SA / MIT; site is community-maintained |

## What makes this different from existing entries

- **Codecademy / Hostinger / DigitalOcean / AI Free API** — single-language, English-only
- **ClawPath** — Chinese & English (2 languages), focused on onboarding
- **install-openclaw.net** — English + Russian (2 languages), VPS-focused
- **clawdbot.tech** — **5 languages, 30+ guides, includes security whitepaper and rename history** (unique dual angle)

## Why this section

- "Tutorials & Guides → Beginner" already lists 6 single-language guides; clawdbot.tech fills the **multilingual gap** that other entries don't address
- clawdbot.tech is **not a deployable tool** (so doesn't fit "Deployment & Infrastructure" with moltworker/OneClickClaw/PrimeClaws)
- clawdbot.tech is **not press** (so doesn't fit "Articles & News → Origins & History" with CNBC/Wikipedia)
- It IS a **community-built tutorial archive** — perfect fit for "Tutorials & Guides → Beginner"

## Disclosure

I'm a contributor/maintainer-adjacent to clawdbot.tech (helped create and curate the multilingual guides). Happy to adjust wording or move sections if you'd prefer a different placement.

## Checklist

- [x] Single, focused addition (1 row to existing table)
- [x] Matches column format (Tutorial | Source | Description)
- [x] Source = "Community" (matches ClawPath precedent)
- [x] Link is permanent homepage (clawdbot.tech/) — not a sub-page that could rot
- [x] No marketing fluff; description is factual