### PR TITLE
Add ClawBench to Research & Surveys

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ OpenClaw supports the **Model Context Protocol (MCP)** — the open standard ado
 
 ### Research & Surveys
 
+- [ClawBench: Can AI Agents Complete Everyday Online Tasks?](https://arxiv.org/abs/2604.08523) - Live-site web-agent benchmark with an OpenClaw harness, request-interception scoring, and five-layer run traces ([Project](https://claw-bench.com/) · [Code](https://github.com/reacher-z/ClawBench))
 - [OpenClaw as Language Infrastructure: A Case-Centered Survey of a Public Agent Ecosystem in the Wild](https://www.preprints.org/manuscript/202603.1060) - Preprints.org · academic survey of the OpenClaw ecosystem across Platform, Security, Societies, and Deployment
 
 ---


### PR DESCRIPTION
## Summary

- Add ClawBench to **Research & Surveys**.
- Link the paper, project page, and open-source implementation.
- Note the selectable OpenClaw harness, request-interception scoring, and run traces.

## Why it fits

ClawBench evaluates web agents on live online tasks and supports OpenClaw as a first-class harness, making it directly useful to readers following research on the OpenClaw ecosystem.

## Validation

- Confirmed the entry is alphabetized within its section.
- Confirmed all three links resolve.
- Confirmed no existing ClawBench entry or prior ClawBench PR.

Disclosure: I am a ClawBench maintainer, and I am submitting this entry in that capacity.
