### PR TITLE
Add NotFair to MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ OpenClaw supports the **Model Context Protocol (MCP)** — the open standard ado
 | `https://api.anchorbrowser.io/mcp` | Cloud browser platform for AI agents |
 | [AI Image Generator & Editor — Nanobanana, GPT Image, ComfyUI](https://github.com/jau123/MeiGen-AI-Design-MCP) | Generate professional AI images through a unified interface that routes across multiple providers. 1,300+ curated prompts, style-aware prompt enhancement, and local ComfyUI workflows. |
 | [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) | MCP server and CLI that generates production-ready visual assets (app icons, favicons, OG images, logos) by routing each request across 30+ image generation models. Zero API key for first run via free-tier providers (Pollinations, Stable Horde, HuggingFace). MIT licensed. |
+| [NotFair](https://github.com/nowork-studio/NotFair) | Hosted OAuth MCP connectors for Google Ads, Meta Ads, and Google Search Console. Lets OpenClaw agents audit live account data and apply approval-gated campaign changes with change history. The public app and skills are MIT licensed; hosted connections are available at [notfair.co](https://notfair.co). |
 | ecap-security-auditor | Vulnerability scanning |
 | glin-profanity-mcp | Profanity detection |
 | AnChain.AI Data MCP | AML compliance |


### PR DESCRIPTION
Adds NotFair to the MCP Servers table. Its hosted OAuth connectors let OpenClaw users inspect Google Ads, Meta Ads, and Google Search Console data and apply approval-gated campaign changes with change history.

Disclosure: I maintain NotFair. The linked repository is public and MIT licensed; the platform connections are hosted at notfair.co. The change is one README line and follows the existing table format.