### PR TITLE
Add Open Index MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ OpenClaw supports the **Model Context Protocol (MCP)** — the open standard ado
 | Server | Description |
 |--------|-------------|
 | `https://api.anchorbrowser.io/mcp` | Cloud browser platform for AI agents |
+| [Open Index](https://github.com/DrDroidLab/open-index) | Structured context graph for domain-specific agents with hybrid search, validated read/write MCP tools, and a portable OpenClaw setup skill. |
 | [AI Image Generator & Editor — Nanobanana, GPT Image, ComfyUI](https://github.com/jau123/MeiGen-AI-Design-MCP) | Generate professional AI images through a unified interface that routes across multiple providers. 1,300+ curated prompts, style-aware prompt enhancement, and local ComfyUI workflows. |
 | [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) | MCP server and CLI that generates production-ready visual assets (app icons, favicons, OG images, logos) by routing each request across 30+ image generation models. Zero API key for first run via free-tier providers (Pollinations, Stable Horde, HuggingFace). MIT licensed. |
 | ecap-security-auditor | Vulnerability scanning |


### PR DESCRIPTION
## Summary

Add Open Index to MCP Servers. It provides domain-specific agents with structured context graphs, hybrid search, validated read/write MCP tools, and a portable OpenClaw setup skill.

Project: https://github.com/DrDroidLab/open-index