### PR TITLE
Add UIZZE anti-UI-slop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Access the built-in web dashboard at `http://localhost:18789/` to chat, manage i
 
 ### Notable Skills
 
+- [UIZZE](https://github.com/uizze/uizze) - Portable anti-UI-slop Skill for coding agents, with a free deterministic MCP preview and UI Slop Gate grounded in 800,000+ real web and iOS screens. Install with `npx skills add https://uizze.com --skill anti-ui-slop`; it runs locally without an account or source upload.
 - [ATXP](https://github.com/atxp-dev/atxp) - Give your OpenClaw agent a funded identity: USDC wallet on Base, `@atxp.email` inbox, phone number, and 100+ paid tools (web search, image/video generation, LLM gateway, SMS, voice). Self-registers in one command — no KYC, no human login. `openclaw skills install https://github.com/atxp-dev/atxp`
 - [LobsterDomains](https://lobsterdomains.xyz) - Register ICANN domains (.com/.xyz/.org/1000+ TLDs) with crypto (USDC/ETH/BTC) via API — built for AI agents to acquire domains autonomously
 - [LinkedIn](https://github.com/Linked-API/linkedin-skills) - General-purpose LinkedIn automation via [Linked API](https://linkedapi.io) — fetch profiles, search people and companies, send messages, manage connections, create posts, and more. Supports Sales Navigator and custom workflows. [ClawHub](https://clawhub.ai/vprudnikoff/linkedapi-linkedin)


### PR DESCRIPTION
Adds UIZZE to Notable Skills as a portable anti-UI-slop skill for coding agents.

- free deterministic MCP preview and UI Slop Gate
- grounded in 800,000+ real web and iOS screens
- local install: `npx skills add https://uizze.com --skill anti-ui-slop`
- no account or source upload for the free skill/preview

Canonical source: https://github.com/uizze/uizze
Website: https://uizze.com