### PR TITLE
Add Parallel Search MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ OpenClaw supports the **Model Context Protocol (MCP)** — the open standard ado
 |--------|-------------|
 | `https://api.anchorbrowser.io/mcp` | Cloud browser platform for AI agents |
 | [AI Image Generator & Editor — Nanobanana, GPT Image, ComfyUI](https://github.com/jau123/MeiGen-AI-Design-MCP) | Generate professional AI images through a unified interface that routes across multiple providers. 1,300+ curated prompts, style-aware prompt enhancement, and local ComfyUI workflows. |
+| [Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) | Free web search and page fetching over Streamable HTTP at `https://search.parallel.ai/mcp`, with no account or API key. Chosen search queries and requested URLs are sent to Parallel. |
 | [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) | MCP server and CLI that generates production-ready visual assets (app icons, favicons, OG images, logos) by routing each request across 30+ image generation models. Zero API key for first run via free-tier providers (Pollinations, Stable Horde, HuggingFace). MIT licensed. |
 | ecap-security-auditor | Vulnerability scanning |
 | glin-profanity-mcp | Profanity detection |


### PR DESCRIPTION
## Why

Adds an optional free web search and page-fetching MCP server to the existing MCP Servers list. The endpoint does not require an account or API key.

## Changes

- Add one alphabetically placed Parallel Search MCP row with the official documentation and Streamable HTTP endpoint.
- Note that chosen search queries and requested URLs are sent to Parallel.
- Preserve all existing servers, providers, configuration, and defaults.

## Validation

- `git diff --check`: passed.
- Exact-row, single-entry, and placement assertions: passed.
- Isolated link reachability check: not completed because the isolated runner could not connect to `docs.parallel.ai`.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.