### PR TITLE
Add Molted (managed OpenClaw fleet hosting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Access the built-in web dashboard at `http://localhost:18789/` to chat, manage i
 | [RapidClaw](https://rapidclaw.dev) | Managed Cloud | Managed OpenClaw hosting for non-technical operators — zero terminal/Docker/SSH setup, deploys in minutes, opinionated defaults. |
 | [PrimeClaws](https://primeclaws.com) | Managed Cloud | Managed OpenClaw Hermes VPS hosting — one-click deploy in 60s, free GPT-5.4/Mistral Large 3/Kimi K2.5/Deepseek V3.2 included, auto-restart, SSH access, full privacy. |
 | [Agent37](https://agent37.com) | Managed Cloud | Managed OpenClaw hosting from $3.99/mo — browser task board, full web terminal, live Linux desktop, scheduled jobs, 1,000+ app integrations via Composio, BYOK keys go straight to the model provider, isolated container per instance |
+| [Molted](https://www.molted.net) | Managed Cloud | Managed OpenClaw fleet hosting for teams and agencies: auto-healing (crash detection under 60s, recovery under 90s, post-mortem per failure), versioned files with point-in-time restore, per-agent email/phone/browser automation, 1,000+ integrations, per-instance-per-day pricing |
 
 ---
 


### PR DESCRIPTION
This adds Molted to the managed cloud entries in the Installation Guides table. Disclosure up front: I am part of the team building it.

Molted is a managed hosting platform built specifically for operating fleets of OpenClaw agents, rather than single instances: auto-healing (crash detection under 60 seconds, recovery under 90 seconds, a post-mortem written for every failure), versioned files with point-in-time restore, managed per-instance OpenClaw version upgrades and rollback, and per-agent email, phone number, browser automation and 1,000+ integrations. It has been in production since January 2026, and the same team runs molted.cloud on top of it with 11,000+ instances hosted.

The description follows the existing row format and stays factual. Happy to trim it down or adjust wording/placement if you prefer.